### PR TITLE
スキップ機能が使えない問題の修正、引用Embedの返信方法を "Reply" へ変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messagequote",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "index.js",
   "license": "MIT",
   "description": "メッセージリンク、IDからメッセージを取得して展開するBot。",

--- a/src/run/_quote.ts
+++ b/src/run/_quote.ts
@@ -5,6 +5,7 @@ export function _quote(client: Client) {
     if (msg.author.bot)　return;
     if(msg.content.startsWith(";")) {
       console.log("Skip: 引用スキップが使用されました。")
+      return;
     }
 
     /**

--- a/src/run/_quote.ts
+++ b/src/run/_quote.ts
@@ -75,8 +75,7 @@ export function _quote(client: Client) {
       );
       quoteEmbed.setImage(file);
     }
-    msg.channel
-      .send({
+    msg.reply({
         embeds: [quoteEmbed],
       })
       .catch(console.error);


### PR DESCRIPTION
- `;` のスキップ機能が使えない問題の修正
- 引用Embedの返信方法を `message.reply` へ変更
> 変更の背景:
> どのメッセージリンクのメッセージなのかを明確にするため