### PR TITLE
feat: Embed 各プロパティの上限等の回避機能を追加

### DIFF
--- a/src/server/service/quote.ts
+++ b/src/server/service/quote.ts
@@ -79,15 +79,12 @@ async function fetchMessage(
   const message = await channel.messages.fetch(messageId);
   if (!message || message.system)
     throw Error('メッセージが存在しないまたは、システムメッセージです。');
+  if ([...message.content].length >= 4096)
+    throw Error('メッセージの内容が上限に達しているため、引用に失敗しました。');
   return message;
 }
 
-function checkMessage(message: Message) {
-  if([...message.content].length >= 4096) throw Error('メッセージの内容が上限に達しているため、引用に失敗しました。')
-}
-
 function createEmbed(message: Message) {
-  checkMessage(message);
   try {
     return getQuoteEmbed({ message: message });
   } catch (error) {

--- a/src/server/service/quote.ts
+++ b/src/server/service/quote.ts
@@ -82,7 +82,12 @@ async function fetchMessage(
   return message;
 }
 
+function checkMessage(message: Message) {
+  if([...message.content].length >= 4096) throw Error('メッセージの内容が上限に達しているため、引用に失敗しました。')
+}
+
 function createEmbed(message: Message) {
+  checkMessage(message);
   try {
     return getQuoteEmbed({ message: message });
   } catch (error) {


### PR DESCRIPTION
- [x] メッセージが4032文字以上だった場合は引用をブロック
- [ ] 添付ファイルの名前が1024文字以上だった場合はファイルの名前を変更するか引用をブロック
- [ ] Stickerの名前が1024文字以上だった場合は名前を変更するか引用をブロック

詳細は #165 を参照

