### PR TITLE
refactor: 環境変数の取り出し処理

### DIFF
--- a/src/server/command/helpCommand.ts
+++ b/src/server/command/helpCommand.ts
@@ -4,13 +4,9 @@ import {
   MessageButton,
   MessageEmbed
 } from 'discord.js';
-import * as dotenv from 'dotenv';
-import { extractEnv } from '../util';
+import { prefix } from '../util';
 
 export const embedColor = '#6AC99D';
-
-dotenv.config();
-const { SKIP_PREFIX: prefix } = extractEnv(['SKIP_PREFIX']);
 
 function createHelp() {
   const helpCommand =

--- a/src/server/command/helpCommand.ts
+++ b/src/server/command/helpCommand.ts
@@ -5,25 +5,12 @@ import {
   MessageEmbed
 } from 'discord.js';
 import * as dotenv from 'dotenv';
+import { extractEnv } from '../util';
 
 export const embedColor = '#6AC99D';
 
 dotenv.config();
-function setupEnv<K extends readonly string[]>(
-  ...keys: K
-): Record<K[number], string> {
-  for (const key of keys) {
-    if (process.env[key] == undefined) {
-      throw new Error(
-        `Error: 次の環境変数を取得することができませんでした: ${key} \n 環境変数の詳細は README を確認してください。`
-      );
-    }
-  }
-
-  return process.env as Record<K[number], string>;
-}
-
-const env = setupEnv('SKIP_PREFIX');
+const { SKIP_PREFIX: prefix } = extractEnv(['SKIP_PREFIX']);
 
 function createHelp() {
   const helpCommand =
@@ -40,13 +27,13 @@ function createHelp() {
     .setColor(embedColor)
     .addField(
       '基本的な使い方',
-      `メッセージリンクをそのまま送信してください。引用をしてほしくない場合はメッセージの最初に\`${env.SKIP_PREFIX}\`をつけてください。`
+      `メッセージリンクをそのまま送信してください。引用をしてほしくない場合はメッセージの最初に\`${prefix}\`をつけてください。`
     )
     .addField(
       'コマンド一覧',
       '**◆ スラッシュコマンドが使える人のみに限られます ◆**\n' + helpCommand
     )
-    .addField('Config', env.SKIP_PREFIX);
+    .addField('Config', prefix);
   const linkButton1 = new MessageButton()
     .setStyle('LINK')
     .setLabel('GitHub')

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,27 +1,17 @@
 import { Client, ClientUser, Intents, version } from 'discord.js';
 import * as dotenv from 'dotenv';
 import { debugCommand, helpCommand, pingCommand } from './command';
+import { extractEnv } from './util';
 import { errorEvent } from './event';
 import { quote } from './service';
 import { autoJoinThread } from './event/autoJoinThread';
 
 // 環境変数の設定
 dotenv.config();
-function setupEnv<K extends readonly string[]>(
-  ...keys: K
-): Record<K[number], string> {
-  for (const key of keys) {
-    if (process.env[key] == undefined) {
-      throw new Error(
-        `Error: 次の環境変数を取得することができませんでした: ${key} \n 環境変数の詳細は README を確認してください。`
-      );
-    }
-  }
-
-  return process.env as Record<K[number], string>;
-}
-
-const env = setupEnv('DISCORD_TOKEN', 'SKIP_PREFIX');
+const { DISCORD_TOKEN: token, SKIP_PREFIX: prefix } = extractEnv([
+  'DISCORD_TOKEN',
+  'SKIP_PREFIX'
+]);
 const clientVersion = process.env.npm_package_version ?? '不明'; // versionのみ別の変数として取得する
 
 // Discordクライアントのインスタンスを作成
@@ -44,12 +34,12 @@ function createLoginLog(user: ClientUser) {
     `接続元ユーザーID: ${user.id}\n` +
     `MessageQuoteのバージョン: v${clientVersion} (https://github.com/approvers/MessageQuote/releases/latest)\n` +
     `discord.jsのバージョン: v${version} (https://github.com/discordjs/discord.js/releases)\n\n` +
-    `SkipPrefix: ${env.SKIP_PREFIX}\n` +
+    `SkipPrefix: ${prefix}\n` +
     '=========\n';
   return console.log(loginLog);
 }
 
-client.login(env.DISCORD_TOKEN).catch(console.error);
+client.login(token).catch(console.error);
 
 client.once('ready', () => {
   console.log(`ログインしています....`);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,18 +1,9 @@
 import { Client, ClientUser, Intents, version } from 'discord.js';
-import * as dotenv from 'dotenv';
 import { debugCommand, helpCommand, pingCommand } from './command';
-import { extractEnv } from './util';
 import { errorEvent } from './event';
 import { quote } from './service';
 import { autoJoinThread } from './event/autoJoinThread';
-
-// 環境変数の設定
-dotenv.config();
-const { DISCORD_TOKEN: token, SKIP_PREFIX: prefix } = extractEnv([
-  'DISCORD_TOKEN',
-  'SKIP_PREFIX'
-]);
-const clientVersion = process.env.npm_package_version ?? '不明'; // versionのみ別の変数として取得する
+import { prefix, token } from './util';
 
 // Discordクライアントのインスタンスを作成
 const intents = new Intents();
@@ -24,6 +15,8 @@ intents.add(
 );
 
 const client = new Client({ intents });
+
+const clientVersion = process.env.npm_package_version ?? '不明'; // versionのみ別の変数として取得する
 
 // ログイン時のイベント
 function createLoginLog(user: ClientUser) {

--- a/src/server/service/quote.ts
+++ b/src/server/service/quote.ts
@@ -5,11 +5,7 @@ import {
   Permissions,
   Snowflake
 } from 'discord.js';
-import { getQuoteEmbed, getErrorEmbed, extractEnv } from '../util';
-import * as dotenv from 'dotenv';
-
-dotenv.config();
-const { SKIP_PREFIX: prefix } = extractEnv(['SKIP_PREFIX']);
+import { getQuoteEmbed, getErrorEmbed, prefix } from '../util';
 
 function getLink(message: Message) {
   if (message.author.bot || !message.guild) return;

--- a/src/server/service/quote.ts
+++ b/src/server/service/quote.ts
@@ -5,29 +5,15 @@ import {
   Permissions,
   Snowflake
 } from 'discord.js';
-import { getQuoteEmbed, getErrorEmbed } from '../util';
+import { getQuoteEmbed, getErrorEmbed, extractEnv } from '../util';
 import * as dotenv from 'dotenv';
 
 dotenv.config();
-function setupEnv<K extends readonly string[]>(
-  ...keys: K
-): Record<K[number], string> {
-  for (const key of keys) {
-    if (process.env[key] == undefined) {
-      throw new Error(
-        `Error: 次の環境変数を取得することができませんでした: ${key} \n 環境変数の詳細は README を確認してください。`
-      );
-    }
-  }
-
-  return process.env as Record<K[number], string>;
-}
-
-const env = setupEnv('SKIP_PREFIX');
+const { SKIP_PREFIX: prefix } = extractEnv(['SKIP_PREFIX']);
 
 function getLink(message: Message) {
   if (message.author.bot || !message.guild) return;
-  if (message.content.startsWith(env.SKIP_PREFIX)) return;
+  if (message.content.startsWith(prefix)) return;
 
   const messageLink =
     /https:\/\/(?:ptb\.|canary\.)?discord(?:app)?\.com\/channels\/(\d+)\/(\d+)\/(\d+)/;

--- a/src/server/util/envManager.ts
+++ b/src/server/util/envManager.ts
@@ -1,3 +1,5 @@
+import * as dotenv from 'dotenv';
+
 export function extractEnv<K extends readonly string[]>(
   keys: K,
   defaluts?: Readonly<Partial<Record<K[number], string>>>
@@ -16,3 +18,9 @@ export function extractEnv<K extends readonly string[]>(
 
   return env as Record<K[number], string>;
 }
+
+dotenv.config();
+export const { DISCORD_TOKEN: token, SKIP_PREFIX: prefix } = extractEnv([
+  'DISCORD_TOKEN',
+  'SKIP_PREFIX'
+]);

--- a/src/server/util/envManager.ts
+++ b/src/server/util/envManager.ts
@@ -2,15 +2,15 @@ import * as dotenv from 'dotenv';
 
 export function extractEnv<K extends readonly string[]>(
   keys: K,
-  defaluts?: Readonly<Partial<Record<K[number], string>>>
+  defaults?: Readonly<Partial<Record<K[number], string>>>
 ): Record<K[number], string> {
   const env: Partial<Record<K[number], string>> = {};
   for (let i = 0; i < keys.length; i++) {
     const key: K[number] = keys[i];
     if (process.env[key] !== undefined && process.env[key] !== '') {
       env[key] = process.env[key];
-    } else if (defaluts && defaluts[key] !== undefined) {
-      env[key] = defaluts[key];
+    } else if (defaults && defaults[key] !== undefined) {
+      env[key] = defaults[key];
     } else {
       throw new Error(`${key} is not defined`);
     }

--- a/src/server/util/envManager.ts
+++ b/src/server/util/envManager.ts
@@ -1,0 +1,18 @@
+export function extractEnv<K extends readonly string[]>(
+  keys: K,
+  defaluts?: Readonly<Partial<Record<K[number], string>>>
+): Record<K[number], string> {
+  const env: Partial<Record<K[number], string>> = {};
+  for (let i = 0; i < keys.length; i++) {
+    const key: K[number] = keys[i];
+    if (process.env[key] !== undefined && process.env[key] !== '') {
+      env[key] = process.env[key];
+    } else if (defaluts && defaluts[key] !== undefined) {
+      env[key] = defaluts[key];
+    } else {
+      throw new Error(`${key} is not defined`);
+    }
+  }
+
+  return env as Record<K[number], string>;
+}

--- a/src/server/util/index.ts
+++ b/src/server/util/index.ts
@@ -1,2 +1,3 @@
 export * from './quoteEmbed';
 export * from './errorEmbed';
+export * from './envManager';


### PR DESCRIPTION
- あっちこっちで `process.env` に依存しているのでそれの修正
- 環境変数が空文字だった際の対策を追加